### PR TITLE
Fix typo in Request Guide

### DIFF
--- a/3.0/guides/request.md
+++ b/3.0/guides/request.md
@@ -321,7 +321,7 @@ const isPlain = request.is('html', 'plain')
 `accepts` will header the `Accept` header to negotiate the best response type for a given HTTP request.
 
 ```javascript
-const type = request.accept('json', 'html')
+const type = request.accepts('json', 'html')
 
 switch (type) {
   


### PR DESCRIPTION
The snippet in the `accepts`' sections was missing a 's'.